### PR TITLE
Enable generated release notes in GitHub release workflows

### DIFF
--- a/.github/workflows/build_release_one_dir.yml
+++ b/.github/workflows/build_release_one_dir.yml
@@ -117,6 +117,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ env.FullVersion }}
+          generate_release_notes: true
           name: ${{ env.ArtifactName }}
           files: |
             ${{ env.ArtifactFullPath }}.zip

--- a/.github/workflows/build_release_one_file.yml
+++ b/.github/workflows/build_release_one_file.yml
@@ -110,6 +110,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ env.FullVersion }}
+          generate_release_notes: true
           name: ${{ env.ArtifactName }} (Compressed)
           files: |
             ${{ env.ArtifactFullPath }}


### PR DESCRIPTION
### Motivation
- Ensure every GitHub Release produced by the repository workflows includes generated release notes so published releases contain release summaries automatically.

### Description
- Added `generate_release_notes: true` to the `softprops/action-gh-release@v1` `with:` block in `.github/workflows/build_release_one_dir.yml` and `.github/workflows/build_release_one_file.yml` so the workflows request autogenerated release notes when creating a release.

### Testing
- Verified the new flag is present with `rg -n "generate_release_notes" .github/workflows/build_release_one_dir.yml .github/workflows/build_release_one_file.yml` and committed the change successfully with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc7e6a03ac8333bc764e21aaae37a4)